### PR TITLE
successfully split up work across a cluster of CPUs and aggregate the results

### DIFF
--- a/commands/google.js
+++ b/commands/google.js
@@ -36,12 +36,8 @@ const cli = meow(`
  * Define helpers
  */
 
-Array.prototype.flatMap = function(mapperFn=x=>x, levels=1) {
-  if (levels === 0) return this
-
-  const flattenedArr = this.reduce((acc, cur) => acc.concat(mapperFn(cur)), [])
-
-  return flattenedArr.flatMap(mapperFn, levels - 1)
+Array.prototype.flatMap = function(mapperFn=x=>x) {
+  return this.reduce((acc, cur) => acc.concat(mapperFn(cur)), [])
 }
 
 // cb for [].prototype.filter

--- a/commands/google.js
+++ b/commands/google.js
@@ -1,13 +1,5 @@
 'use strict'
 
-/*
- Here are the list of bugs with this current working version:
-
- 1.) Duplicate results
- 2.) Results come in out of order
- 
-*/
-
 /**
  * Dependencies
  */


### PR DESCRIPTION
Here are the three bugs that reside within this PR:
~~1.) Duplicate results~~
~~2.) Results come in out of order~~
 ~~3.) No results printed/returned when the --count is less than the total number of CPUs; also the process never exits~~

Nonetheless, significant progress was made.

Edit: fixed bug no. 3. 

Another edit: Bugs 1 and 2 were false alarms! 😅 I ran the script on the master branch and got the same exact results in the same order. I guess in the case of bug no. 2, different results are returned from puppetteer's chrome compared to my version of chrome (although the no. 1 result is always consistent across both), and in the case of bug no. 1, for whatever reason, some results come up twice (the same thing happened on the master branch).